### PR TITLE
Permit charting of aggregation/extra fields in a queryset

### DIFF
--- a/chartit/validation.py
+++ b/chartit/validation.py
@@ -84,7 +84,7 @@ def _clean_categories(categories, source):
                             %(categories, type(categories)))
     field_aliases = {}
     for c in categories:
-        if c in source.query.aggregates.keys():
+        if c in source.query.aggregates.keys() or c in source.query.extra.keys():
             field_aliases[c] = c
         else:
             field_aliases[c] = _validate_field_lookup_term(source.model, c)


### PR DESCRIPTION
Changes to the validation methods to permit use of aggregation/extra fields when creating charts; use case for us was when creating PivotCharts and wanting to chart the combination of several fields.
