### PR TITLE
fix simplejson

### DIFF
--- a/chartit/templatetags/chartit.py
+++ b/chartit/templatetags/chartit.py
@@ -1,7 +1,7 @@
 from itertools import izip_longest
 
 from django import template
-from django.utils import simplejson
+import simplejson
 from django.utils.safestring import mark_safe
 from django.conf import settings
 import posixpath


### PR DESCRIPTION
Since you cannot import it from django.utils -> you do a pip install simplejson and then do an import.
works perfectly!
