### PR TITLE
Allow dictionary fields in conjunction with lambda fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+dist
+django_chartit.egg-info

--- a/chartit/validation.py
+++ b/chartit/validation.py
@@ -240,11 +240,17 @@ def _convert_dps_to_dict(series_list):
                             raise APIInputError("Expecting a basestring or "
                                                 "dict in place of: %s" %tv)
                 elif isinstance(term,tuple):
-                            t,fn = term
+                    t,fn = term
+                    if isinstance(t, dict):
+                        for tk, tv in t.items():
                             opt = copy.deepcopy(options)
                             opt['fn'] = fn
-                            series_dict[t] = opt 
-         
+                            opt['field'] = tv
+                            series_dict[tk] = opt
+                    else:
+                        opt = copy.deepcopy(options)
+                        opt['fn'] = fn
+                        series_dict[t] = opt
         elif isinstance(terms, dict):
             for tk, tv in terms.items():
                 if isinstance(tv, basestring):


### PR DESCRIPTION
This allows dictionary terms to be used with lambda functions too. Example:

```python
'terms': [
    ({'date-x': 'date'}, lambda d: d.toordinal()),
    {'Total': 'count'}
]
```