### PR TITLE
Add comment for django setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,8 @@ You can install Django-Chartit from PyPI. Just do ::
 
     $ pip install django_chartit
 
+Then, add `chartit` to `INSTALLED_APPS` in "settings.py".
+
 You also need supporting JavaScript libraries. See the
 `Required JavaScript Libraries`_ section for more details.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,8 @@ You can install Django-Chartit from PyPI. Just do ::
 
     $ pip install django_chartit
 
+Then, add `chartit` to `INSTALLED_APPS` in "settings.py".
+
 You also need supporting JavaScript libraries. See the
 `Required JavaScript Libraries`_ section for more details.
 


### PR DESCRIPTION
Adding `chartit` to INSTALLED_APPS is a mandatory for using `chartit`. But the documentation doesn't describe this.