### PR TITLE
Drop dependency on simplejson. Fixes #3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,8 @@ Changelog
     * Update the path to demoproject.settings when building docs. Fixes
       a problem which caused some API docs to be empty
     * Fix ValueError: not enough values to unpack (expected 2, got 0)
-      with PivotChart when the QuerySet returns empty data.
+      with PivotChart when the QuerySet returns empty data
+    * Dropped requirement on `simplejson`
 
 * 0.2.5 (August 3, 2016)
     * Workaround Python 3 vs. Python 2 list sort issue which breaks

--- a/chartit/charts.py
+++ b/chartit/charts.py
@@ -7,7 +7,7 @@ from .highcharts import HCOptions
 from .validation import clean_pcso, clean_cso, clean_x_sortf_mapf_mts
 from .exceptions import APIInputError
 from .chartdata import PivotDataPool, DataPool
-import simplejson
+import json
 
 
 class BaseChart(object):
@@ -34,7 +34,7 @@ class BaseChart(object):
                 });
             });
         """
-        return simplejson.dumps(self.hcoptions)
+        return json.dumps(self.hcoptions)
 
 
 class Chart(BaseChart):

--- a/demoproject/README.rst
+++ b/demoproject/README.rst
@@ -11,7 +11,7 @@ Installation & Configuration
 This demoproject is installed as part of the `django_chartit` package.
 To install additional dependecies execute the command ::
 
-    pip install docutils Django django-markup-deprecated Pygments simplejson
+    pip install docutils Django django-markup-deprecated Pygments
 
 To run the demo project ::
 

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,3 +1,2 @@
 # used for building the docs on Red The Docs
 Django
-simplejson

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,6 @@ setup(
         'Topic :: Software Development',
     ],
     platforms='any',
-    install_requires=[
-        'simplejson',
-    ],
     keywords='django charts',
     author='Praveen Gollakota',
     author_email='pgollakota@gmail.com',


### PR DESCRIPTION
It looks like converting Decimal to float does the trick of dropping simplejson. I'm leaving this PR here to soak for a while. All the tests and charts in the demo project continue to work but we don't really do anything fancy there.  I'm hoping somebody with more elaborate data set may give this a test before I merge it.

@grantmcconnaughey can you review please?

-----------------

Before submitting a PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description.
* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Reviewed the diff manually for unexpected or unrelated changes.
* [x] Updated `README.rst` with change log.
* [x] Tested changes manually.
* [ ] Added automated tests.
* [x] `make coverage` tests are passing.

[1]: http://chris.beams.io/posts/git-commit/

